### PR TITLE
Made change to Gemfile for rest-client versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source :gemcutter
 
 gem "thor",        "~>0.14.6"
-gem "rest-client", "~>1.4", :require => "rest_client"
+gem "rest-client", "~>1.4.2", :require => "rest_client"
 gem "highline",    '~>1.6.1'
 gem "json_pure"
 gem "escape",      "~>0.0.4"


### PR DESCRIPTION
The engineyard gem has the rest-client version dependency as `~> 1.4` which has problems because that means rest-client 1.6.1 to 1.99, before 2.0 can be installed, which can break things. Some people in the community forums have been running into problems and I think this might be the solution a lot of them reverted back to engineyard gem 1.3.7 from 1.3.11 and said that solved the problem for them for the time being.

The dependency I believe should be defined as `~> 1.4.x`, but I talked with Ben and he said we should just make it the latest release of 1.4 so I made it 1.4.2. Here is more on why that is something we should do http://blog.zenspider.com/2008/10/rubygems-howto-preventing-cata.html.

--Danish
