### PR TITLE
Quote ssh commmand string

### DIFF
--- a/lib/engineyard/cli.rb
+++ b/lib/engineyard/cli.rb
@@ -188,9 +188,8 @@ module EY
 
       raise NoCommandError.new if cmd.nil? and hosts.count != 1
 
-      esc_cmd = cmd ? Escape.shell_command(cmd) : ""
       hosts.each do |host|
-        system "ssh #{environment.username}@#{host} #{esc_cmd}"
+        system Escape.shell_command(["ssh", "#{environment.username}@#{host}", cmd].compact)
       end
     end
 

--- a/spec/ey/ssh_spec.rb
+++ b/spec/ey/ssh_spec.rb
@@ -126,7 +126,6 @@ describe "ey ssh with a multi-part command" do
 
   def verify_ran(scenario)
     ssh_target = scenario[:ssh_username] + '@' + scenario[:master_hostname]
-    puts "RAW_SSH_COMMANDS: #{@raw_ssh_commands.inspect}"
     @raw_ssh_commands.should == ["ssh #{ssh_target} 'cd /path/to/place; ls'"]
   end
 


### PR DESCRIPTION
This patch permits the following use of `ey ssh` to work:

<pre>ey ssh "cd /data/myap/current/; ls -al"</pre>


Previously the "ls -al" was run on the local machine.
