### PR TITLE
Changed File.open mode to 'rb'

### DIFF
--- a/lib/engineyard/model/environment.rb
+++ b/lib/engineyard/model/environment.rb
@@ -83,7 +83,7 @@ module EY
       def upload_recipes_at_path(recipes_path)
         recipes_path = Pathname.new(recipes_path)
         if recipes_path.exist?
-          upload_recipes recipes_path.open('r')
+          upload_recipes recipes_path.open('rb')
         else
           raise EY::Error, "Recipes file not found: #{recipes_path}"
         end


### PR DESCRIPTION
Currently, the `recipes.tgz` file is being open in `read` mode. Changed the mode to be `rb` or `binary read` so it doesn't try to read it as a text file.
