### PR TITLE
Add ability to pass arbitrary ssh options to the ssh executable

### DIFF
--- a/lib/engineyard/cli.rb
+++ b/lib/engineyard/cli.rb
@@ -209,6 +209,8 @@ module EY
       :desc => "Run command on the master database server"
     method_option :db_slaves, :type => :boolean,
       :desc => "Run command on the slave database servers"
+    method_option :ssh_flags, :type => :string, :aliases => %w(-s),
+      :desc => "Pass these strings to ssh command"
     method_option :utilities, :type => :array, :lazy_default => true,
       :desc => "Run command on the utility servers with the given names. If no names are given, run on all utility servers."
 
@@ -219,7 +221,7 @@ module EY
       raise NoCommandError.new if cmd.nil? and hosts.size != 1
 
       hosts.each do |host|
-        system Escape.shell_command(['ssh', "#{environment.username}@#{host}", cmd].compact)
+        system Escape.shell_command(['ssh', options[:ssh_flags], "#{environment.username}@#{host}", cmd].compact)
       end
     end
 


### PR DESCRIPTION
This comes in handy when we need to pass flags to the ssh executable; e.g., `-o StrictHostKeyChecking=no`.

The flag `-s` might not be optimal.

Also, I need help coming up with the specs.
