### PR TITLE
config hash is now @configuration.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,7 +40,7 @@ Command:
         [--ignore-default-branch]             # Force a deploy of the specified branch even if a default is set
     -e, [--environment=ENVIRONMENT]           # Environment in which to deploy this application
     -c, [--account=ACCOUNT]                   # Name of the account in which the environment can be found
-        [--extra-deploy-hook-options key:val] # Additional options to be made available in deploy hooks (in the 'config' hash)
+        [--extra-deploy-hook-options key:val] # Additional options to be made available in deploy hooks (in the '@configuration' hash)
 
 
   Description:

--- a/lib/engineyard/cli.rb
+++ b/lib/engineyard/cli.rb
@@ -48,7 +48,7 @@ module EY
     method_option :verbose, :type => :boolean, :aliases => %w(-v),
       :desc => "Be verbose"
     method_option :extra_deploy_hook_options, :type => :hash, :default => {},
-      :desc => "Additional options to be made available in deploy hooks (in the 'config' hash)"
+      :desc => "Additional options to be made available in deploy hooks (in the '@configuration' hash)"
     def deploy
       EY.ui.info "Loading application data from EY Cloud..."
 
@@ -174,7 +174,7 @@ module EY
     method_option :verbose, :type => :boolean, :aliases => %w(-v),
       :desc => "Be verbose"
     method_option :extra_deploy_hook_options, :type => :hash, :default => {},
-      :desc => "Additional options to be made available in deploy hooks (in the 'config' hash)"
+      :desc => "Additional options to be made available in deploy hooks (in the '@configuration' hash)"
     def rollback
       app, environment = fetch_app_and_environment(options[:app], options[:environment], options[:account])
 


### PR DESCRIPTION
I found out that hard way that the 'config' hash in deploy hooks should now be referred to as '@configuration'.
