### PR TITLE
Add a --token option to use a particular API key for a single invocation

### DIFF
--- a/lib/engineyard/thor.rb
+++ b/lib/engineyard/thor.rb
@@ -4,7 +4,7 @@ module EY
   module UtilityMethods
     protected
     def api
-      @api ||= EY::CLI::API.new options[:token]
+      @api ||= EY::CLI::API.new options[:api_token]
     end
 
     def repo
@@ -36,7 +36,7 @@ module EY
   class Thor < ::Thor
     include UtilityMethods
 
-    class_option :token, :type => :string, :desc => "Use API token TOKEN to authenticate this command" 
+    class_option :"api-token", :type => :string, :desc => "Use API-TOKEN to authenticate this command"
 
     check_unknown_options!
 

--- a/spec/engineyard/cli/api_spec.rb
+++ b/spec/engineyard/cli/api_spec.rb
@@ -21,9 +21,9 @@ describe EY::CLI::API do
     ENV.delete('ENGINEYARD_API_TOKEN')
   end
   
-  it "uses the token from the --token option if set" do
+  it "uses the token from the --api-token option if set" do
     capture_stdout do
-      EY::CLI.send(:dispatch, "help", [], {:token => 'clitoken'}, {}) do |cli|
+      EY::CLI.send(:dispatch, "help", [], {:api_token => 'clitoken'}, {}) do |cli|
         cli.send(:api).token.should == 'clitoken'
       end
     end


### PR DESCRIPTION
In many scenarios, such as an automated deploy from CI, it makes sense to make transient use of your API token. There is currently the ability to do this via an
environment variable, but let's face it, environment variables are fugly.
