### PR TITLE
Add verbose flag for listing environments

### DIFF
--- a/lib/engineyard/cli.rb
+++ b/lib/engineyard/cli.rb
@@ -115,12 +115,13 @@ module EY
 
     method_option :all, :type => :boolean, :aliases => %(-a)
     method_option :simple, :type => :boolean, :aliases => %(-s)
+    method_option :verbose, :type => :boolean, :aliases => %(-v)
     def environments
       if options[:all] && options[:simple]
         # just put each env
         puts api.environments.map {|env| env.name}
       elsif options[:all]
-        EY.ui.print_envs(api.apps, EY.config.default_environment, options[:simple])
+        EY.ui.print_envs(api.apps, EY.config.default_environment, options[:simple], options[:verbose])
       else
         apps = api.apps_for_repo(repo)
 
@@ -133,7 +134,7 @@ module EY
           EY.ui.warn(NoAppError.new(repo).message + "\nUse #{self.class.send(:banner_base)} environments --all to see all environments.")
         end
 
-        EY.ui.print_envs(apps, EY.config.default_environment, options[:simple])
+        EY.ui.print_envs(apps, EY.config.default_environment, options[:simple], options[:verbose])
       end
     end
     map "envs" => :environments

--- a/lib/engineyard/cli/ui.rb
+++ b/lib/engineyard/cli/ui.rb
@@ -72,7 +72,7 @@ module EY
         end
       end
 
-      def print_envs(apps, default_env_name = nil, simple = false)
+      def print_envs(apps, default_env_name = nil, simple = false, verbose = false)
         if simple
           envs = apps.map{ |app| app.environments.to_a }
           puts envs.flatten.map{|env| env.name }.uniq
@@ -89,6 +89,11 @@ module EY
                 default_text = env.name == default_env_name ? " [default]" : ""
 
                 puts "  #{short_name}#{default_text} (#{icount} #{iname})"
+                if verbose
+                  env.instances.each do |inst|
+                    puts "    #{inst.role} #{inst.public_hostname} #{inst.status}"
+                  end
+                end
               end
             else
               puts "  (This application is not in any environments; you can make one at #{EY.config.endpoint})"

--- a/spec/ey/list_environments_spec.rb
+++ b/spec/ey/list_environments_spec.rb
@@ -50,6 +50,12 @@ describe "ey environments" do
       ey %w[environments -a -s], :debug => false
       @out.split(/\n/).sort.should == ["bakon", "beef", "giblets"]
     end
+
+    it "outputs instances with -v" do
+      ey %w[environments -a -v], :debug => false
+      @out.should include "solo app_master_hostname.compute-1.amazonaws.com running"
+    end
+
   end
 end
 


### PR DESCRIPTION
This update makes possible to see the instance roles and hostnames from the CLI.  It is useful when you need to SSH into a specific instance or SCP to download application log files.
