### PR TITLE
Fixing docs on --extra-deploy-hook-options

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -41,8 +41,8 @@ Command:
         [--ignore-default-branch]             # Force a deploy of the specified branch even if a default is set
     -e, [--environment=ENVIRONMENT]           # Environment in which to deploy this application
     -c, [--account=ACCOUNT]                   # Name of the account in which the environment can be found
-        [--extra-deploy-hook-options key:val] # Additional options to be made available in deploy hooks (in the 'config' hash)
-
+        [--extra-deploy-hook-options=key:val] # Additional options to be made available in deploy hooks (in the @configuration hash)
+                                              # Each additional option is space separated: --extra-deploy-hook-options=key:val key1:val1
 
   Description:
     This command must be run with the current directory containing the app to be

--- a/lib/engineyard/cli.rb
+++ b/lib/engineyard/cli.rb
@@ -49,7 +49,7 @@ module EY
     method_option :verbose, :type => :boolean, :aliases => %w(-v),
       :desc => "Be verbose"
     method_option :extra_deploy_hook_options, :type => :hash, :default => {},
-      :desc => "Additional options to be made available in deploy hooks (in the 'config' hash)"
+      :desc => "Additional options to be made available in deploy hooks (in the @configuration hash)"
     def deploy
       EY.ui.info "Loading application data from EY Cloud..."
 
@@ -175,7 +175,7 @@ module EY
     method_option :verbose, :type => :boolean, :aliases => %w(-v),
       :desc => "Be verbose"
     method_option :extra_deploy_hook_options, :type => :hash, :default => {},
-      :desc => "Additional options to be made available in deploy hooks (in the 'config' hash)"
+      :desc => "Additional options to be made available in deploy hooks (in the @configuration hash)"
     def rollback
       app, environment = fetch_app_and_environment(options[:app], options[:environment], options[:account])
 


### PR DESCRIPTION
The extra deploy hook options actually show up in the @configuration hash, not the 'config' hash.
