### PR TITLE
HighLine::String should not be serialized in ey.yml

### DIFF
--- a/lib/engineyard/cli/ui.rb
+++ b/lib/engineyard/cli/ui.rb
@@ -50,7 +50,7 @@ module EY
               highline.ask(question) do |q|
                 q.echo = "*"        if password
                 q.default = default if default
-              end
+              end.to_s
             end
           end
         end


### PR DESCRIPTION
I noticed that the `migration_command` got serialized as a highline string when migrating to v2.0.1

``` yaml
--- 
environments: 
  app_production: 
    migration_command: !str:HighLine::String rake db:migrate
    migrate: true
    branch: master
```

This breaks deployment. Fixed it in a general way for stings fetched via `HighLine.new.ask`.
