### PR TITLE
Using MultiJson instead of json_pure

### DIFF
--- a/engineyard.gemspec
+++ b/engineyard.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('rest-client', '~>1.6.0')
   s.add_dependency('highline', '~>1.6.1')
-  s.add_dependency('json_pure')
+  s.add_dependency('multi_json')
   s.add_dependency('escape', '~>0.0.4')
   s.add_dependency('engineyard-serverside-adapter', '=2.0.4')   # This line maintained by rake; edits may be stomped on
   s.add_dependency('engineyard-cloud-client', '~>1.0.7')

--- a/spec/ey/deploy_spec.rb
+++ b/spec/ey/deploy_spec.rb
@@ -350,7 +350,7 @@ describe "ey deploy" do
       if @ssh_commands.last =~ /--config (.*?)(?: -|$)/
         # the echo strips off the layer of shell escaping, leaving us
         # with pristine JSON
-        JSON.parse `echo #{$1}`
+        MultiJson.load `echo #{$1}`
       end
     end
 

--- a/spec/ey/rollback_spec.rb
+++ b/spec/ey/rollback_spec.rb
@@ -36,7 +36,7 @@ describe "ey rollback" do
       if @ssh_commands.last =~ /--config (.*?)(?: -|$)/
         # the echo strips off the layer of shell escaping, leaving us
         # with pristine JSON
-        JSON.parse `echo #{$1}`
+        MultiJson.load `echo #{$1}`
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require 'net/ssh'
 require 'fakeweb'
 require 'fakeweb_matcher'
 
-require 'json'
+require 'multi_json'
 
 # Engineyard gem
 $LOAD_PATH.unshift(File.join(EY_ROOT, "lib"))


### PR DESCRIPTION
We use engineyard gem as a dependency in our rails app and have problems with json_pure in its dependencies.

Because our app is quite big, we use a lot of other gems, many of which depend on json gem. This produces situations, where you don't really know what implementation you're using and what exactly gets loaded when you do 'require "json"'.

Also, we had a very hard-to-track bug related to that. The problem was that we couldn't recreate it in development, cause it was using different "json" from production.

Well, anyway. Depending on multi_json seems to be a great choice for you guys, mostly because it doesn't break things in apps like ours. Also, it uses pure-ruby single-file implementation called okjson if nothing more speedy is available, so folks on jruby or rubinius won't be left behind by this change.

Somewhat relevant: https://github.com/engineyard/engineyard-serverside-adapter/pull/3
