### PR TITLE
Allow -t, and --each options to `ey ssh`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## NEXT
 
   * New command `ey servers -e env` shows servers for a specified environment in a machine/user readable format.
+  * `ey ssh` accepts new options -t and --each. Experimintal option -L is also supported.
   * Uses newest version of engineyard-serverside 2.3.1
     * Abort rollbacks if unexpected files are found in the /data/app/releases/ directory because they disrupt the ability to find the previous and latest releases.
     * Supports alternative deploy strategy that fetches an archive at a remote URI and expands it. (Not yet supported from the command line)

--- a/lib/engineyard/error.rb
+++ b/lib/engineyard/error.rb
@@ -4,7 +4,7 @@ module EY
 
   class NoCommandError < EY::Error
     def initialize
-      super "Must specify a command to run via ssh"
+      super "Specify a command to run via ssh or use --each to cycle through each server one at a time."
     end
   end
 


### PR DESCRIPTION
-t may be used to run commands that require a tty.
--each is used to loop through each of the servers one by one when a command is not given.

Experimental option -L is included as well. Please send feedback in a
github issue if you need this option.
