### PR TITLE
Legacy ey.yml crashes `ey environment` opaquely

### DIFF
--- a/lib/engineyard/config.rb
+++ b/lib/engineyard/config.rb
@@ -83,7 +83,7 @@ module EY
 
     def default_environment
       d = environments.find do |name, env|
-        env["default"]
+        env && env["default"]
       end
       d && d.first
     end

--- a/spec/engineyard/config_spec.rb
+++ b/spec/engineyard/config_spec.rb
@@ -19,6 +19,11 @@ describe EY::Config do
       File.open('ey.yml', "w") {|f| f << "this isn't a hash" }
       expect { EY::Config.new }.to raise_error(RuntimeError, "ey.yml load error: Expected a Hash but a String was returned.")
     end
+
+    it "doesnt crash on nil environment" do
+      write_yaml({"environments" => {"production" => nil}}, 'ey.yml')
+      EY::Config.new.default_environment.should be_nil
+    end
   end
 
   describe "endpoint" do


### PR DESCRIPTION
My `ey.yml` contained nil environment definitions.  This results in the very opaque and untraceable (side note: could `ey` add a `--trace` option?):

```
undefined method `[]' for nil:NilClass
```

I don't know whether this is our fault or due to something in ancient EY history (we've been on the platform since early 2010, so we have some cruft).  But in any case, it's very easy to end up in this situation if you delete the config for an environment but forget to delete the key.  Then you end up with this very hard to trace error (it took me a half hour to figure out what was going on), so I propose this is an improvement all around.
