### PR TITLE
Use net-ssh with keep alive. Set server keep alive to 60

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## NEXT
 
+  * Use net-ssh 2.7 which support keepalive. Set server keep alive to 60 to avoid idle connections being closed.
   * Uses newest version of engineyard-serverside 2.3.9
     * Run `git remote prune origin` to remove possible branch name collisions before fetching.
     * Update git fetch command to use + for heads and not just tags. "If the optional plus + is used, the local ref is updated even if it does not result in a fast-forward update."

--- a/engineyard.gemspec
+++ b/engineyard.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency('escape', '~>0.0.4')
   s.add_dependency('engineyard-serverside-adapter', '=2.2.0')   # This line maintained by rake; edits may be stomped on
   s.add_dependency('engineyard-cloud-client', '~>1.0.16')
-  s.add_dependency('net-ssh', '~>2.2')
+  s.add_dependency('net-ssh', '~>2.7')
   s.add_dependency('launchy', '~>2.1')
 
   s.add_development_dependency('rspec', '~>2.0')

--- a/lib/engineyard/serverside_runner.rb
+++ b/lib/engineyard/serverside_runner.rb
@@ -115,7 +115,7 @@ Authentication Failed. Things to fix:
           level = debug.downcase.to_sym
         end
       end
-      {:paranoid => false, :verbose => level}
+      {:paranoid => false, :verbose => level, :keepalive => true, :keepalive_interval => 60}
     end
 
     def ssh(cmd, hostname, username, out, err)


### PR DESCRIPTION
This will help avoid dropped connections during long processes.

This will go along with the keep alive setting in serverside to help avoid dropping deploy connections that will end up succeeding.
