### PR TITLE
Restrict rake to a version that works on 1.8.7

### DIFF
--- a/engineyard.gemspec
+++ b/engineyard.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency('launchy', '~>2.1')
 
   s.add_development_dependency('rspec', '~>2.0')
-  s.add_development_dependency('rake')
+  s.add_development_dependency('rake', '~>10.0.0')
   s.add_development_dependency('rdoc')
   s.add_development_dependency('fakeweb')
   s.add_development_dependency('fakeweb-matcher')


### PR DESCRIPTION
This is going into the 2-3-stable branch only. We don't need this change for the ruby19 only master.
