### PR TITLE
Update .travis.yml to only build ruby targets >= 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - ruby-head
-  - rbx
-  - ree
   - jruby-head
 matrix:
   allow_failures:
-    - rvm: rbx
     - rvm: jruby-head
     - rvm: ruby-head
 notifications:
@@ -24,6 +20,3 @@ notifications:
     on_success: always
     on_failure: always
     on_start: true
-branches:
-  only:
-    - master


### PR DESCRIPTION
This is the first step in dropping support for ruby 1.8.
