### PR TITLE
[SS-215] Adds data_bags directory to recipes archive

### DIFF
--- a/lib/engineyard/cli/recipes.rb
+++ b/lib/engineyard/cli/recipes.rb
@@ -80,7 +80,11 @@ module EY
           end
 
           recipes_file = Tempfile.new("recipes")
+
           cmd = "tar czf '#{recipes_file.path}' cookbooks/"
+          if FileTest.exist?("data_bags")
+            cmd = cmd + " data_bags/"
+          end
 
           unless system(cmd)
             raise EY::Error, "Could not archive recipes.\nCommand `#{cmd}` exited with an error."


### PR DESCRIPTION
http://tickets.engineyard.com/issue/SS-215
- Why was the change necessary?
  We have customers on the old UI who want encrypted data bags support
  but the current way to do it requires creating the archive manually.
- How does the change address the issue?
  This checks for the presence of the "data_bags" directory as a sibling
  of the "cookbooks" directory and if found, adds it to the archive.
- What side effects/risks does this change have?
  This should only affect the recipes upload functionality but it should
  be pretty safe.
- What test scenarios were (or will be) used to validate change
  I made sure that all current specs were still green after this change
  and then tested that on a live environment, I'm able to find the
  data_bags directory in /etc/chef-custom/recipes
