### PR TITLE
Close stdin immediately after connecting through net-ssh

### DIFF
--- a/lib/engineyard/serverside_runner.rb
+++ b/lib/engineyard/serverside_runner.rb
@@ -144,6 +144,9 @@ Authentication Failed. Things to fix:
             channel.on_request("exit-signal") do |_, data|
               exit_code = 255
             end
+
+            # sending eof declares no more data coming from this end (close stdin)
+            channel.eof!
           end
         end
 


### PR DESCRIPTION
We don't support sending information to stdin when executing commands
through net-ssh anyway, so there's no reason to leave stdin open.

This should solve the problem we encountered where user scripts could
block waiting to read from stdin.
