### PR TITLE
Remove direct dependency on rest-client

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## NEXT
 
   * Bump version of engineyard-cloud-client to 2.1.1 to use newer RestClient with better ssl version detection.
+  * Remove direct dependency on rest-client, which breaks gem version requirements for existing engineyard gem and the already released engineyard-cloud-client.
 
 ## v3.0.0 (2014-08-26)
 

--- a/engineyard.gemspec
+++ b/engineyard.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir.glob("spec/**/*")
 
-  s.add_dependency('rest-client', '~>1.7')
   s.add_dependency('highline', '~>1.6.1')
   s.add_dependency('escape', '~>0.0.4')
   s.add_dependency('engineyard-serverside-adapter', '=2.2.0')   # This line maintained by rake; edits may be stomped on

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,7 +1,6 @@
 require 'engineyard/cli'
 
 require 'realweb'
-require 'rest_client'
 require 'open4'
 require 'stringio'
 


### PR DESCRIPTION
This breaks gem version requirements for the already released
engineyard-cloud-client which switched the version it requires.

engineyard gem does not rely on rest-client directly.

As an aside, we had a little debate about how to semver this properly.
- To preserve the ability to install 3.0.0 (technically a broken release because it has a strict requirement on a gem it does not use) I would have to yank engineyard-cloud-client 2.1.1 and release 2.2.0 with the fix.
- Ideally, however, 3.0.0 would have been able to auto-update to the new cloud client because it specifies a loose `~>` on cloud client to allow for bug fixes like the ssl version fix in cloud-client. However, because 3.0.0's dependencies are specified too strictly, engineyard 3.0.0 is broken and cannot be installed.

I'm choosing to push 3.0.1 with the fix so that the ssl fix is forced rather than trying to preserve the installation of 3.0.0 by choice. engineyard 3.0.0 is broken in both its gem version requirements and the ssl version selection bug and so leaving it uninstallable because of broken requirements is acceptable.
