### PR TITLE
Adds the `ey console` command to start a Rails console.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
   * 
 
+## v3.2.0 ()
+
+  * New command `ey console` opens a Rails console session on the master app server.
+
 ## v3.1.3 (2015-03-04)
 
   * Loose gem deps on gems owned by Engine Yard.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
   * 
 
-## v3.2.0 ()
+##
 
   * New command `ey console` opens a Rails console session on the master app server.
 

--- a/lib/engineyard/cli.rb
+++ b/lib/engineyard/cli.rb
@@ -522,13 +522,16 @@ WARNING: Interrupting again may prevent Engine Yard Cloud from recording this
       exit exits.detect {|status| status != 0 } || 0
     end
 
-    desc "console [--environment ENVIRONMENT", "Open a Rails console session to the master app server."
+    desc "console [--app APP] [--environment ENVIRONMENT] [--account ACCOUNT]", "Open a Rails console session to the master app server."
     long_desc <<-DESC
       Opens a Rails console session on app master.
     DESC
     method_option :environment, type: :string, aliases: %w(-e),
       required: true, default: '',
       desc: "Environment to console into"
+    method_option :app, type: :string, aliases: %w(-a),
+      required: true, default: '',
+      desc: "Name of the application"
     method_option :account, type: :string, aliases: %w(-c),
       required: true, default: '',
       desc: "Name of the account in which the environment can be found"

--- a/spec/ey/console_spec.rb
+++ b/spec/ey/console_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+print_my_args_ssh = "#!/bin/sh\necho ssh $*"
+
+shared_examples_for "running ey console" do
+  given "integration"
+
+  def extra_ey_options
+    {:prepend_to_path => {'ssh' => "#!/bin/sh\necho ssh $*"}}
+  end
+
+  def command_to_run(opts)
+    cmd = ["console"]
+    cmd << "--environment" << opts[:environment] if opts[:environment]
+    cmd << "--quiet"                             if opts[:quiet]
+    cmd
+  end
+end
+
+describe "ey console" do
+  include_examples "running ey console"
+
+  it "complains if it has no app master" do
+    login_scenario "one app, many environments"
+    ey %w[console -e bakon], :expect_failure => true
+    expect(@err).to match(/'bakon' does not have any matching instances/)
+  end
+
+  it "opens the console on the right server" do
+    login_scenario "one app, one environment"
+    ey command_to_run(:environment => 'giblets', :verbose => true)
+    expect(@raw_ssh_commands.select do |command|
+      command =~ /^ssh -t turkey@app_master_hostname.+ bash -lc '.+bundle exec rails console'$/
+    end).not_to be_empty
+    expect(@raw_ssh_commands.select do |command|
+      command =~ /^ssh -t turkey.+$/
+    end.count).to eq(1)
+  end
+
+  it "is quiet" do
+    login_scenario "one app, one environment"
+    ey command_to_run(:environment => 'giblets', :quiet => true)
+    expect(@out).to match(/ssh.*-t turkey/)
+    expect(@out).not_to match(/Loading application data/)
+  end
+
+  it "runs in bash by default" do
+    login_scenario "one app, one environment"
+    ey command_to_run(:environment => 'giblets', :quiet => true)
+    expect(@out).to match(/ssh.*bash -lc '.+bundle/)
+  end
+
+  it "raises an error when there are no matching hosts" do
+    login_scenario "one app, one environment, no instances"
+    ey command_to_run(:environment => 'giblets', :quiet => true), :expect_failure => true
+  end
+end


### PR DESCRIPTION
Hey guys,

First of all, thanks for this gem - I've used it a lot throughout the past few years.

This pull request is basically a helper/wrapper for this command.
`ey ssh -t 'cd /data/<app_name>/current && bundle exec rails console' -e <environment>`

I couldn't find any record of a command for this, so here's a pull request. It's very much similar to the ssh command (since it's an ssh session + running a command). This will end up being helpful to me even if this doesn't make it into the gem.

Before I finish this up and write the specs for it, I just want to see what you guys think about a command like this being in the gem. If you think it's worthy, I'll move it forward.

Re: code duplication, I see two alternatives.
1. Call the ssh command inside console command. But, I need to add the `shell` and `pty` options to the console command for this to work - it doesn't seem ideal since without `pty` it won't work at all.
2. Somehow pass options to the ssh command. The options are frozen, so that seems out of the question.