### PR TITLE
Fix extra output of `ey help`

### DIFF
--- a/lib/engineyard/thor.rb
+++ b/lib/engineyard/thor.rb
@@ -152,7 +152,8 @@ Please specify --app=app_name or add this application at #{config.endpoint}"
               subcommands = self.class.printable_tasks.sort_by{|s| s[0] }
               subcommands.reject!{|t| t[0] =~ /#{cmd} help$/}
               ui.print_help(subcommands)
-              ui.say self.class.send(:class_options_help, ui)
+              ui.say
+              self.class.send(:class_options_help, ui)
               ui.say "See #{banner_base} #{cmd} help COMMAND" +
                 " for more information on a specific subcommand." if args.empty?
             else


### PR DESCRIPTION
`EY::Thor.subcommand_help` prints the return value from `Thor::Base::ClassMethods#class_options_help`.
Because of that, the help messages might contain extra `{}` string like this:

![selection_371](https://cloud.githubusercontent.com/assets/43346/12134278/3714ce06-b471-11e5-83e9-ce9f8bd7cba8.png)
