### PR TITLE
EYPP-2102: Update ruby dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
   - ruby-head
   - jruby-head
 matrix:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 The Engine Yard command line utility.
 
-### Installing on Ruby 1.8.7 or 1.9.2
+### Installing on Ruby 2.1 or greater
 
 **NOTE: This has *no effect* on your Engine Yard environment ruby version. This
 is only regarding the local development Ruby version for running this gem. An

--- a/engineyard.gemspec
+++ b/engineyard.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 2.0')
   s.add_development_dependency('rake', '~> 10.4')
   s.add_development_dependency('rdoc', '~> 4.2')
-  s.add_development_dependency('fakeweb', '~> 1.3')
+  s.add_development_dependency('webmock', '~> 3.3')
   s.add_development_dependency('sinatra', '~> 1.4')
   s.add_development_dependency('realweb', '~> 1.0.1')
   s.add_development_dependency('open4', '~> 1.0.1')

--- a/engineyard.gemspec
+++ b/engineyard.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.post_install_message = File.read("PostInstall.txt")
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 2.2'
 
   s.files = Dir.glob("{bin,lib}/**/*") + %w(LICENSE README.md)
   s.executables = ["ey"]
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency('engineyard-cloud-client', '~> 3.0')
   s.add_dependency('net-ssh', '~>4.2')
   s.add_dependency('launchy', '~>2.1')
-  s.add_dependency('ey-core', '~>3.1.4')
+  s.add_dependency('ey-core', '~>3.5')
 
   s.add_development_dependency('rspec', '~> 3.7')
   s.add_development_dependency('rake', '~> 10.4')

--- a/engineyard.gemspec
+++ b/engineyard.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.post_install_message = File.read("PostInstall.txt")
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.1'
 
   s.files = Dir.glob("{bin,lib}/**/*") + %w(LICENSE README.md)
   s.executables = ["ey"]

--- a/engineyard.gemspec
+++ b/engineyard.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake', '~> 10.4')
   s.add_development_dependency('rdoc', '~> 4.2')
   s.add_development_dependency('fakeweb', '~> 1.3')
-  s.add_development_dependency('fakeweb-matcher', '~> 1.2')
   s.add_development_dependency('sinatra', '~> 1.4')
   s.add_development_dependency('realweb', '~> 1.0.1')
   s.add_development_dependency('open4', '~> 1.0.1')

--- a/engineyard.gemspec
+++ b/engineyard.gemspec
@@ -24,15 +24,15 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir.glob("spec/**/*")
 
-  s.add_dependency('highline', '~> 1.6.1')
+  s.add_dependency('highline', '~> 1.7')
   s.add_dependency('escape', '~> 0.0.4')
   s.add_dependency('engineyard-serverside-adapter', '~> 2.2')
   s.add_dependency('engineyard-cloud-client', '~> 3.0')
-  s.add_dependency('net-ssh', '~>2.7')
+  s.add_dependency('net-ssh', '~>4.2')
   s.add_dependency('launchy', '~>2.1')
   s.add_dependency('ey-core', '~>3.1.4')
 
-  s.add_development_dependency('rspec', '~> 2.0')
+  s.add_development_dependency('rspec', '~> 3.7')
   s.add_development_dependency('rake', '~> 10.4')
   s.add_development_dependency('rdoc', '~> 4.2')
   s.add_development_dependency('webmock', '~> 3.3')

--- a/engineyard.gemspec
+++ b/engineyard.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency('highline', '~> 1.6.1')
   s.add_dependency('escape', '~> 0.0.4')
   s.add_dependency('engineyard-serverside-adapter', '~> 2.2')
-  s.add_dependency('engineyard-cloud-client', '~> 2.1')
+  s.add_dependency('engineyard-cloud-client', '~> 3.0')
   s.add_dependency('net-ssh', '~>2.7')
   s.add_dependency('launchy', '~>2.1')
   s.add_dependency('ey-core', '~>3.1.4')

--- a/spec/engineyard/cli/api_spec.rb
+++ b/spec/engineyard/cli/api_spec.rb
@@ -23,8 +23,7 @@ describe EY::CLI::API do
   context "without saved api token" do
     before(:each) do
       clean_eyrc
-      FakeWeb.register_uri(:post, "http://fake.local/api/v2/authenticate", :body => %|{"api_token": "asdf"}|, :content_type => 'application/json')
-
+      stub_request(:post, "http://fake.local/api/v2/authenticate").to_return(body: %|{"api_token": "asdf"}|, headers: { content_type: 'application/json' })
       EY::CLI::UI::Prompter.enable_mock!
       EY::CLI::UI::Prompter.add_answer "my@email.example.com"
       EY::CLI::UI::Prompter.add_answer "secret"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,6 @@ require 'net/ssh'
 
 # Bundled gems
 require 'fakeweb'
-require 'fakeweb_matcher'
 
 require 'multi_json'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ require 'escape'
 require 'net/ssh'
 
 # Bundled gems
-require 'fakeweb'
+require 'webmock/rspec'
 
 require 'multi_json'
 
@@ -57,7 +57,7 @@ RSpec.configure do |config|
 
   config.before(:all) do
     clean_eyrc
-    FakeWeb.allow_net_connect = false
+    WebMock.disable_net_connect!
     ENV["CLOUD_URL"] = nil
     ENV["NO_SSH"] = "true"
   end
@@ -72,12 +72,12 @@ shared_examples_for "integration" do
   use_git_repo('default')
 
   before(:all) do
-    FakeWeb.allow_net_connect = true
+    WebMock.allow_net_connect!
     ENV['CLOUD_URL'] = EY::CloudClient::Test::FakeAwsm.uri
   end
 
   after(:all) do
     ENV.delete('CLOUD_URL')
-    FakeWeb.allow_net_connect = false
+    WebMock.disable_net_connect!
   end
 end


### PR DESCRIPTION
- Replace fakeweb for webmock (fakeweb last release is from August 22, 2010)
- Update engineyard-cloud-client 

PS: Only merge after engineyard-cloud-client 3.0 is properly released
